### PR TITLE
Updated Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 
 
-FROM tensorflow/tensorflow:2.8.3-gpu-jupyter
+FROM tensorflow/tensorflow:latest-gpu
 
 MAINTAINER David Doukhan david.doukhan@gmail.com
 


### PR DESCRIPTION
Changed Dockerfile base image to 

tensorflow/tensorflow:latest-gpu

- The previous base image is two years old maybe, it's better to stay on the latest tensorflow version
- No one needs Jupyter as part of the base image for this project
- I already tested it and use this version in production, it works fine